### PR TITLE
admin/change-default-segmentation-ceiling-adjust

### DIFF
--- a/actk/tests/utils/test_image_utils.py
+++ b/actk/tests/utils/test_image_utils.py
@@ -106,21 +106,24 @@ def test_get_normed_image_array(
 
 
 @pytest.mark.parametrize(
-    "image, cell_index, expected_image",
+    "image, cell_index, cell_ceiling_adjustment, expected_image",
     [
         (
             "example_normed_image_array_0.ome.tiff",
             1,
+            7,
             "example_selected_and_adjusted_array_0_1.ome.tiff",
         ),
         (
             "example_normed_image_array_0.ome.tiff",
             2,
+            7,
             "example_selected_and_adjusted_array_0_2.ome.tiff",
         ),
         (
             "example_normed_image_array_0.ome.tiff",
             3,
+            7,
             "example_selected_and_adjusted_array_0_3.ome.tiff",
         ),
     ],
@@ -129,6 +132,7 @@ def test_select_and_adjust_segmentation_ceiling(
     data_dir,
     image,
     cell_index,
+    cell_ceiling_adjustment,
     expected_image,
 ):
     """
@@ -140,7 +144,9 @@ def test_select_and_adjust_segmentation_ceiling(
     """
     # Get actual
     image = AICSImage(data_dir / image).get_image_data("CYXZ", S=0, T=0)
-    actual_image = image_utils.select_and_adjust_segmentation_ceiling(image, cell_index)
+    actual_image = image_utils.select_and_adjust_segmentation_ceiling(
+        image, cell_index, cell_ceiling_adjustment=cell_ceiling_adjustment
+    )
 
     # Read expected
     expected_image = AICSImage(data_dir / expected_image)

--- a/actk/utils/image_utils.py
+++ b/actk/utils/image_utils.py
@@ -167,7 +167,7 @@ def get_normed_image_array(
 
 
 def select_and_adjust_segmentation_ceiling(
-    image: np.ndarray, cell_index: int, cell_ceiling_adjustment: int = 7
+    image: np.ndarray, cell_index: int, cell_ceiling_adjustment: int = 0
 ) -> np.ndarray:
     """
     Select and adjust the cell shape "ceiling" for a specific cell in the provided
@@ -184,7 +184,7 @@ def select_and_adjust_segmentation_ceiling(
     cell_ceiling_adjustment: int
         The adjust to use for raising the cell shape ceiling. If <= 0, this will be
         ignored and cell data will be selected but not adjusted.
-        Default: 7
+        Default: 0
 
     Returns
     -------


### PR DESCRIPTION
The new segmentations do not need to be adjusted like the old ones do. So updating the default parameters on the cell segmentation selection function to not adjust the segmenation at all.