### PR TITLE
change default walltime and scaling behavior

### DIFF
--- a/actk/bin/all.py
+++ b/actk/bin/all.py
@@ -128,13 +128,13 @@ class All:
                     cores=worker_cpu,
                     memory=worker_mem,
                     queue="aics_cpu_general",
-                    walltime="10:00:00",
+                    walltime="9-23:00:00",
                     local_directory=str(log_dir),
                     log_directory=str(log_dir),
                 )
 
                 # Spawn workers
-                cluster.scale(n_workers)
+                cluster.scale(jobs=n_workers)
                 log.info("Created SLURMCluster")
 
                 # Use the port from the created connector to set executor address

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,13 @@ dev_requirements = [
 ]
 
 step_workflow_requirements = [
-    "aics_dask_utils==0.2.0",
+    "aics_dask_utils>=0.2.0",
     "bokeh>=2.1.0",
     "dask[bag]>=2.19.0",
     "dask_jobqueue>=0.7.0",
     "datastep>=0.1.8",
     "distributed>=2.19.0",
-    "docutils==0.15.2",  # needed for botocore (quilt dependency)
+    "docutils>=0.15.2",  # needed for botocore (quilt dependency)
     "fire",
     "prefect>=0.12.1",
     "psutil",
@@ -54,9 +54,9 @@ step_workflow_requirements = [
 requirements = [
     *step_workflow_requirements,
     # project requires
-    "aicsfeature==0.2.1",
+    "aicsfeature>=0.2.1",
     "aicsimageio>=3.2.3",
-    "aicsimageprocessing==0.7.4",
+    "aicsimageprocessing>=0.7.4",
     "matplotlib>=3.2.0",
     "numpy>=1.18.2",
     "pandas>=1.0.3",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ dev_requirements = [
 step_workflow_requirements = [
     "aics_dask_utils>=0.2.0",
     "bokeh>=2.1.0",
-    "botocore==1.18",
+    "boto3==1.15",
     "dask[bag]>=2.19.0",
     "dask_jobqueue>=0.7.0",
     "datastep>=0.1.8",

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ dev_requirements = [
 step_workflow_requirements = [
     "aics_dask_utils>=0.2.0",
     "bokeh>=2.1.0",
+    "botocore==1.18",
     "dask[bag]>=2.19.0",
     "dask_jobqueue>=0.7.0",
     "datastep>=0.1.8",


### PR DESCRIPTION
- changed default distributed wall-time to just under ten days.  the previous default of 10 hrs was not long enough.  should perhaps consider making this an cmd-line arg.
- changed the scaling behavior from `n=n` to `jobs=n`. this page has some hints at how the different scaling modes work https://jobqueue.dask.org/en/latest/howitworks.html?highlight=scale but honestly i haven't found anything definitive.  So far, using `jobs=n` give more intuitive scaling -- it asks for `n` times the amount of resources originally allocated in the cmd-line config.  previously it was trying to split up those resources into `n` workers, and i was running into memory exceeded errors.